### PR TITLE
Add document charset <meta> tag

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
 <html>
   <head>
+    <meta charset='utf-8'>
     <link rel='stylesheet' type='text/css' href='style.css'>
     <link rel="shortcut icon" type="image/png" href="favicon.png">
     <link rel="stylesheet" href="https://fonts.googleapis.com/icon?family=Material+Icons"><!-- for world icon -->


### PR DESCRIPTION
While serving locally, UTF-8 characters such as the dropdown icon didn't render correctly:

![Before](https://cloud.githubusercontent.com/assets/9948030/24829443/153712b8-1c48-11e7-902e-2b663388af79.png)

After this change:

![After](https://cloud.githubusercontent.com/assets/9948030/24829444/19fa8d84-1c48-11e7-996c-5f077089e368.png)
