### PR TITLE
Center/align dropdown globe as discussed

### DIFF
--- a/index.html
+++ b/index.html
@@ -14,7 +14,7 @@
         <li id="name">sds</li>
         <li>
           <div class="dropdown" id="dropdown">
-            <button onclick="dropit()" class="dropdownButton" id="dropButton"><i class="material-icons md-18">language</i>  English ▾</button>
+            <button onclick="dropit()" class="dropdownButton" id="dropButton"><i class="material-icons md-18 dropdownIcon">language</i><span>English ▾</span></button>
             <div id="dropOptions" class="dropdown-content">
             </div>
           </div>

--- a/style.css
+++ b/style.css
@@ -136,6 +136,14 @@ a:active {
   font-size: 1rem;
   border: none;
   cursor: pointer;
+
+  /* Vertically center text */
+  display: flex;
+  flex-align: center;
+}
+
+.dropdownIcon {
+  margin-right: 5px;
 }
 
 /* Dropdown button on hover & focus */


### PR DESCRIPTION
Before:

![Before](https://cloud.githubusercontent.com/assets/9948030/24829536/2343d3a8-1c4a-11e7-99a9-811e5956b7f2.png)

After:

![After](https://cloud.githubusercontent.com/assets/9948030/24829538/27f316d4-1c4a-11e7-93ef-af00c4b356c5.png)

The text is vertically aligned by using flexbox. This doesn't affect any browser support, since flexbox was already being used in the code (ex. style.css, `#credits ul { ... }`).
